### PR TITLE
little axis bug in default plotting of time-freq difference stat

### DIFF
--- a/eeg_mvpa/adam_compare_MVPA_stats.m
+++ b/eeg_mvpa/adam_compare_MVPA_stats.m
@@ -135,7 +135,7 @@ end
 if strcmpi(mpcompcor_method,'fdr')
     % FDR CORRECTION
     [~,ClassPvals] = ttest(ClassTotal{1},ClassTotal{2},'alpha',indiv_pval,'tail',tail); % bug spotted by jvd: because pval wasn't specified as explicit 'param' and 'tail' was, it crashed
-    h = fdr_bh(squeeze(ClassPvals),cluster_pval);
+    h = fdr_bh(squeeze(ClassPvals),cluster_pval,'dep');
     ClassPvals(~h) = 1;
     pStruct = []; % still need to implement
 elseif strcmpi(mpcompcor_method,'cluster_based')

--- a/eeg_mvpa/adam_compute_group_ERP.m
+++ b/eeg_mvpa/adam_compute_group_ERP.m
@@ -378,13 +378,13 @@ for cCond = 1:numel(ClassTotal) % loop over stats
     
     % determine condname
     if strcmpi(electrode_method,'subtract')
-        condname =  [origcondname ' channel subtraction'];
+        condname =  [origcondname ' channel subtraction of ' cellarray2csvstring(FT_ERP.channelpool)];
     elseif strcmpi(condition_method,'subtract')
-        condname =  [origcondname ' subtraction'];
+        condname =  [origcondname ' subtraction (' cellarray2csvstring(FT_ERP.channelpool) ')'];
     elseif strcmpi(condition_method,'average')
-        condname = [origcondname ' average'];
+        condname = [origcondname ' average (' cellarray2csvstring(FT_ERP.channelpool) ')'];
     else
-        condname = [origcondname ' erp' num2str(condition_def(cCond))];
+        condname = [origcondname ' erp' num2str(condition_def(cCond)) ' (' cellarray2csvstring(FT_ERP.channelpool) ')'];
     end
     
     % get some stats
@@ -395,7 +395,7 @@ for cCond = 1:numel(ClassTotal) % loop over stats
         % FDR CORRECTION
         [~,ClassPvals] = ttest(ClassTotal{cCond},chance,indiv_pval,tail);
         ClassPvals = shiftdim(squeeze(ClassPvals));
-        h = fdr_bh(squeeze(ClassPvals),cluster_pval);
+        h = fdr_bh(squeeze(ClassPvals),cluster_pval,'dep');
         ClassPvals(~h) = 1;
     elseif strcmp(mpcompcor_method,'cluster_based')
         % CLUSTER BASED CORRECTION
@@ -465,12 +465,16 @@ if strcmpi(electrode_method,'subtract') %iscell(electrode_def{1})
     end
     FT_EEG.trial = trial;
     FT_EEG.channelpool = channelpool;
-elseif strcmpi(electrode_method,'average') % extract and average
+elseif strcmpi(electrode_method,'average')
     if ~iscell(electrode_def)
         electrode_def = {electrode_def};
     end
     FT_EEG = select_channels_from_FT_EEG(FT_EEG,electrode_def);
-    FT_EEG.channelpool = FT_EEG.label;
+    if numel(electrode_def) > 1
+        FT_EEG.channelpool = ['avg of ' cellarray2csvstring(FT_EEG.label)];
+    else
+        FT_EEG.channelpool = FT_EEG.label;
+    end
 else
     error('Specify cfg.electrode_method as ''average'' (default) or ''subtract''');
 end

--- a/eeg_mvpa/adam_plot_MVPA.m
+++ b/eeg_mvpa/adam_plot_MVPA.m
@@ -314,6 +314,10 @@ if isfield(stats,'cfg')
     stats = rmfield(stats,'cfg');
 end
 v2struct(cfg);
+
+if ~isempty(stats.settings.freqs)
+    plot_dim = 'freq_time';
+end
 if exist('plot_dim','var') && strcmpi(plot_dim, 'freq_time')
     swapaxes = false;
 else

--- a/eeg_mvpa/adam_plot_MVPA.m
+++ b/eeg_mvpa/adam_plot_MVPA.m
@@ -315,9 +315,16 @@ if isfield(stats,'cfg')
 end
 v2struct(cfg);
 
-if strcmp(stats.settings.dimord,'freq_time') % this may conflict with avgfreq lineplots?
-    plot_dim = 'freq_time';
-end
+% @Joram: this should not be fixed here, but at the level of adam_compute_group_MVPA (if at all).
+% The only reason I used plot_dim at the plotting stage here was to make sure swapaxes was working
+% properly. Other than that, plot_dim is really only used at the adam_compute_group_ stage. By
+% design, you currently have to indicate cfg.plot_dim = 'freq_time'; if you want to 
+% compute and plot frequency by time. This cannot be derived from settings.dimord, because it would
+% indeed conflict with avfreq lineplots or time_time plotting in certain frequency bands, as you
+% correctly inferred.
+% if strcmp(stats.settings.dimord,'freq_time') % this may conflict with avgfreq lineplots?
+%     plot_dim = 'freq_time';
+% end
 if exist('plot_dim','var') && strcmpi(plot_dim, 'freq_time')
     swapaxes = false;
 else

--- a/eeg_mvpa/adam_plot_MVPA.m
+++ b/eeg_mvpa/adam_plot_MVPA.m
@@ -315,7 +315,7 @@ if isfield(stats,'cfg')
 end
 v2struct(cfg);
 
-if ~isempty(stats.settings.freqs)
+if strcmp(stats.settings.dimord,'freq_time') % this may conflict with avgfreq lineplots?
     plot_dim = 'freq_time';
 end
 if exist('plot_dim','var') && strcmpi(plot_dim, 'freq_time')

--- a/eeg_mvpa/classify_RAW_eeglab_data.m
+++ b/eeg_mvpa/classify_RAW_eeglab_data.m
@@ -183,7 +183,7 @@ basis_sigma = 1; % default width of basis set if not a delta, if this is empty, 
 unbalance_events = false;
 unbalance_classes = false;
 detrend_eeg = false;
-whiten = true;
+whiten = false;
 whiten_test_using_train = false;
 for c=1:numel(methods)
     if any(strcmpi(methods{c},{'linear', 'quadratic', 'diagLinear', 'diagQuadratic', 'mahalanobis'}))
@@ -276,6 +276,9 @@ for c=1:numel(methods)
     end
     if any(strcmpi(methods{c},{'detrend','detrend_eeg'}))
         detrend_eeg = true;
+    end
+    if any(strcmpi(methods{c},{'whiten'}))
+        whiten = true;
     end
     if any(strcmpi(methods{c},{'nowhiten'}))
         whiten = false;

--- a/eeg_mvpa/classify_TFR_from_eeglab_data.m
+++ b/eeg_mvpa/classify_TFR_from_eeglab_data.m
@@ -178,7 +178,7 @@ basis_sigma = 1; % default width of basis set if not a delta, if this is empty, 
 unbalance_events = false;
 unbalance_classes = false;
 detrend_eeg = false;
-whiten = true;
+whiten = false;
 whiten_test_using_train = false;
 for c=1:numel(methods)
     if any(strcmpi(methods{c},{'linear', 'quadratic', 'diagLinear', 'diagQuadratic', 'mahalanobis'})) == 1
@@ -274,6 +274,9 @@ for c=1:numel(methods)
     end
     if any(strcmpi(methods{c},{'detrend','detrend_eeg'}))
         detrend_eeg = true;
+    end
+    if any(strcmpi(methods{c},{'whiten'}))
+        whiten = true;
     end
     if any(strcmpi(methods{c},{'nowhiten'}))
         whiten = false;

--- a/general_stats/cellarray2csvstring.m
+++ b/general_stats/cellarray2csvstring.m
@@ -1,4 +1,9 @@
 function csvstring = cellarray2csvstring(cellarray)
+% return input if it's already a string
+if ischar(cellarray)
+    csvstring = cellarray;
+    return
+end
 % converts a cell array to a csv string, removes empty values
 if size(cellarray,1) == 1
     cellarray = cellarray';


### PR DESCRIPTION
Johannes, klein bugfixje: als je cfg leeg laat bij plotten van TFR difference stats, kwam swapaxes op true, waardoor ook de x/y tick labels raar werden. Kleine if-then boven gezet die plot_dim='freq_time' erbij zet als de freq setting gevuld is. Maar dat zou misschien weer een GAT van een freq-band kunnen dwarsbomen dus even dubbel checken. 