### PR TITLE
minor bug fix in remove IC

### DIFF
--- a/eeg_preprocessing/remove_ICs.m
+++ b/eeg_preprocessing/remove_ICs.m
@@ -41,7 +41,7 @@ if nargin < 4
     hor_ver_blink_gd = [];
 end
 if ischar(hor_ver_blink_gd)
-    hor_ver_blink_gd = str2double(hor_ver_blink_gd);
+    hor_ver_blink_gd = str2num(hor_ver_blink_gd);
 end
 if isempty(hor_ver_blink_gd) || numel(hor_ver_blink_gd)~=4
     disp('removing only EOG ICs (default)');


### PR DESCRIPTION
The `hor_ver_blink_gd` argument in `remove_ICs.m` is currently not handled correctly whenever there are leading `0`s. Specifically, those leading `0`s will be dropped. For example, `'0,0,1,0'` will be changed to `10`

I suggest fixing it by using `str2num` rather than `str2double`.



