### PR TITLE
update detrend_and_epoch

### DIFF
--- a/eeg_TFR/eeglab2ft.m
+++ b/eeg_TFR/eeglab2ft.m
@@ -1,14 +1,19 @@
-function FT_EEG = eeglab2ft(EEG,filepath,continuous)
+function FT_EEG = eeglab2ft(EEG,filepath,continuous,epochwindow)
 % function FT_EEG = eeglab2ft(EEG,filepath,continuous)
 % Wrapper function to import EEG lab data to a fieldtrip, including
 % conditions
 % EEG can either be an eeglab struct, or be the filename which contains the
 % eeglab data. In the latter case, filepath must also be specified
 % If continuous == true, the function works on un-epoched data
+% epochwindow (start, stop) is in seconds. It is only relevant for continuous data. It discards
+% events that do not have all the data required to generate a full epoch for that event.
 % In this case the trial info field will also contain a second column that has the time stamps of
 % the events, expressed in milliseconds (not in seconds, although the time field is in seconds!)
 % J.J.Fahrenfort, VU 2014, 2016
 
+if nargin < 4
+    epochwindow = [];
+end
 if nargin < 3
     continuous = false;
 end
@@ -24,13 +29,12 @@ if ~isstruct(EEG)
 end
 FT_EEG = eeglab2fieldtrip_local(EEG, 'preprocessing');
 % also get events using pop_export
-FT_EEG.trialinfo = pop_exportepoch(EEG,continuous);
+FT_EEG.trialinfo = pop_exportepoch(EEG,continuous,epochwindow);
 
 function data = eeglab2fieldtrip_local(EEG, fieldbox, transform)
 
 if nargin < 2
     error('missing 2nd argument');
-    return;
 end
 
 % start with an empty data object 

--- a/eeg_preprocessing/detrend_and_epoch.m
+++ b/eeg_preprocessing/detrend_and_epoch.m
@@ -145,7 +145,7 @@ if polynomial_order < 0
 end
 
 % convert to FT_EEG format for ease of processing
-FT_EEG = eeglab2ft(EEG,[],true); % third argument indicated data is continuous
+FT_EEG = eeglab2ft(EEG,[],true,[start_epoch end_epoch]/1000); % third argument indicated data is continuous, fourth argument is to indicate epoch window in seconds
 clear EEG;
 
 % obtain names to work with


### PR DESCRIPTION
Detrending now excludes events for which not all data is available (i.e. for which the full epoch would start or end before data collection started or ended).