### PR TITLE
Bug in electrode selection during time-frequency decoding

### DIFF
--- a/eeg_mvpa/classify_TFR_from_eeglab_data.m
+++ b/eeg_mvpa/classify_TFR_from_eeglab_data.m
@@ -339,7 +339,7 @@ end
 % load data 
 for cFile = 1:numel(filenames)
     msettings = [];
-    msettings.channelset = bundlename_or_bundlelabels;
+    msettings.channelpool = bundlename_or_bundlelabels;
     msettings.erp_baseline = erp_baseline; % NOTE: different in RAW.
     msettings.resample_eeg = false; % NOTE: this line is different in RAW. No resampling done here (yet)...
     msettings.do_csd = do_csd;


### PR DESCRIPTION
A bug in which the channel poooling was improperly selected when running a time-frequency decoding analysis. As a result, there was no channel selection when restricting channels during time frequency decoding.