### PR TITLE
Classify without labels, restrict training set

### DIFF
--- a/eeg_TFR/compute_bins_on_FT_EEG.m
+++ b/eeg_TFR/compute_bins_on_FT_EEG.m
@@ -18,7 +18,7 @@ function [ FT_EEG, newCondSet ] = compute_bins_on_FT_EEG(FT_EEG,condSet,field,la
 % condSet{1} = [ 1, 1, 1];
 % condSet{2} = [ 2, 2, 2];
 % averages 3 instances from condition 1 together into a single instance and averages 3 instances
-% from condition 2 together into a single instance Again, leftover trials are discarded (if there
+% from condition 2 together into a single instance. Again, leftover trials are discarded (if there
 % were 10 trials of condition 1, the new set will contain 3 trial averaged instances of condition 1,
 % and 1 'old' trial will be discarded.
 %

--- a/eeg_mvpa/BDM_and_FEM_FT_EEG.m
+++ b/eeg_mvpa/BDM_and_FEM_FT_EEG.m
@@ -61,7 +61,7 @@ if compute_performance
 else
     labelsOfTestSet =  NaN(size(test_FT_EEG.trialinfo)); % when no meaningful class definition exists in the test set
 end
-    
+
 % initialize output
 FEM = [];
 BDM = [];
@@ -155,10 +155,10 @@ for t=1:size(allTrainData,2)
             if compute_performance
                 BDM.ClassOverTime(t2,t) = compute_class_performance(scores,labelsOfTestSet,measuremethod);
             else
-                BDM.ClassOverTime = NaN;
+                BDM.ClassOverTime = mean(scores(:,1),1); % return the probability of assigning the label of the first class
             end
             % save classifier confidence scores
-            if save_confidence && t == t2 % also returning confidence scores, only the diagonal (or we will run out of memory)
+            if save_confidence && t == t2 % also returning confidence scores, Only the diagonal or we will run out of memory, but can be changed if necessary.
                 BDM.ScoresOverTime(:,t,:) = scores;
             end
         end

--- a/eeg_mvpa/adam_plot_MVPA.m
+++ b/eeg_mvpa/adam_plot_MVPA.m
@@ -127,6 +127,9 @@ plot_order = [];
 figure_axis = 'horizontal';
 folder = '';
 startdir = '';
+if isfield(stats(1).cfg, 'symmetry')
+    symmetry = stats(1).cfg.symmetry;
+end
 if strcmpi(stats(1).settings.dimord, 'freq_time')
     swapaxes = false;
 else
@@ -725,7 +728,7 @@ if strcmpi(plottype,'2D')
     end
     set(ax,'YTickLabel',ticklabel);
     hold off;
-else
+else % 3D
     % determine significant time points
     origdata = data;
     if ~isempty(pVals) && ~strcmpi(mpcompcor_method,'none')

--- a/eeg_mvpa/classify_TFR_from_eeglab_data.m
+++ b/eeg_mvpa/classify_TFR_from_eeglab_data.m
@@ -176,6 +176,7 @@ unbalance_classes = false;
 whiten = false;
 whiten_test_using_train = false;
 reproduce = false;
+restrict_trainset = [];
 for c=1:numel(methods)
     if any(strcmpi(methods{c},{'linear', 'quadratic', 'diagLinear', 'diagQuadratic', 'mahalanobis'})) == 1
         method = methods{c};
@@ -270,6 +271,9 @@ for c=1:numel(methods)
     if any(strcmpi(methods{c},{'reproduce'}))
         reproduce = true;
     end
+    if strncmpi(methods{c},'restrict_trainset',17)
+        restrict_trainset = str2double(strrep(methods{c}(18:end),'-',','));
+    end
 end
 if ~do_FEM && ~do_BDM
     do_BDM = true;
@@ -326,6 +330,9 @@ if ~compute_performance && nFolds > 1
     compute_performance = true;
     wraptext('WARNING: Always computing performance when using leave-on-out. Only set cfg.compute_performance = ''no'' when you do not have useful class labels to compute performance with. Defaulting back to cfg.compute_performance = ''yes''.',80);
 end
+if ~compute_performance
+    measuremethod = 'P(1stclass)'; % showing the average probability of the trial being classified as the first class in the class definition
+end
 % display class specification
 wraptext('These are the class specifications. Each row contains the event codes that go into a single class (first row training, second row testing):',80);
 celldisp(condSet,'class_spec');
@@ -372,18 +379,51 @@ if numel(filenames) == 1
     chanlocs{2} = chanlocs{1};
 end
 
-% extract some relevant trial info, training and testing data
+% extract trialinfo, balance bins and restrict trial numbers
 for cSet = 1:2
     thisCondSet = get_this_condset(condSet,cSet);
     if unbalance_events
-        trialinfo{cSet} = FT_EEG(cSet).trialinfo;
+        trialinfo{cSet} = FT_EEG(cSet).trialinfo; % use this for makefolds
     else
         % bin/balance dataset (default action, this is not to achieve actual binnning, it just applies within-class balancing of conditions)
         FT_EEG_BINNED(cSet) = compute_bins_on_FT_EEG(FT_EEG(cSet),thisCondSet,'trial','original');
-        trialinfo{cSet} = FT_EEG_BINNED(cSet).trialinfo;
-        oldindex{cSet} = FT_EEG_BINNED(cSet).oldindex;
-        % a bit of hack to assign event number -99 to unbalanced events (i.e. by selecting those events from thisCondSet that were not used to compute FT_EEG_BINNED)
-        FT_EEG(cSet).trialinfo(setdiff(find(ismember(FT_EEG(cSet).trialinfo,[thisCondSet{:}])),[oldindex{cSet}{:}])) = -99;
+        trialinfo{cSet} = FT_EEG_BINNED(cSet).trialinfo; % WE USE THIS BINNED TRIALINFO FOR MAKEFOLDS, THE ORIGINAL SETINDEX IS RECOVERED LATER ON!
+        oldindex{cSet} = FT_EEG_BINNED(cSet).oldindex;   % OLDINDEX IS USED FOR RECOVERY TO ORIGINAL SETINDEX
+        % a little hack to assign event number -99 to unbalanced events in FT_EEG (i.e. by selecting those events from thisCondSet that are not in FT_EEG_BINNED)
+        origindex = find(ismember(FT_EEG(cSet).trialinfo,[thisCondSet{:}])); % all indices
+        keepindex = [FT_EEG_BINNED(cSet).oldindex{:}]; % expand to get indices belonging to bins after balancing
+        removeindex = setdiff(origindex,keepindex);
+        FT_EEG(cSet).trialinfo(removeindex) = -99;
+    end
+    % limit trial numbers in each class of the training set if so desired, slightly complicated due to balancing
+    if cSet == 1 && ~isempty(restrict_trainset)
+        removeindex = [];
+        nClasses = numel(thisCondSet);
+        for cClass = 1:numel(thisCondSet)
+            nCodesInClass = numel(thisCondSet{cClass});
+            if unbalance_events % don't care about event codes
+                restrictN = floor(restrict_trainset/nClasses);
+            else % distribute evenly across instances in this class
+                restrictN = floor((restrict_trainset/nClasses)/nCodesInClass); % trialindex is binned, so divide by number of event codes in each class
+            end
+            origindex = find(ismember(trialinfo{cSet},thisCondSet{cClass}));
+            if numel(origindex) > restrictN
+                removeindex = [removeindex origindex(restrictN+1:end)];
+            else
+                disp('WARNING: There are fewer trial instances in this class than the number you want to limit them by, so keeping the original number.');
+            end
+        end
+        % assign event number -99 to remove events that exceed the restriction
+        trialinfo{cSet}(removeindex) = -99;
+        if unbalance_events
+            FT_EEG(cSet).trialinfo = trialinfo{cSet}; % also put the new trialinfo back in FT_EEG
+        else
+            % a little hack to assign event number -99 to unbalanced events in FT_EEG (i.e. by selecting those events from thisCondSet that were not used to compute FT_EEG_BINNED)
+            origindex = find(ismember(FT_EEG(cSet).trialinfo,[thisCondSet{:}])); % all indices before restricting
+            keepindex = [ FT_EEG_BINNED.oldindex{ismember(FT_EEG_BINNED(cSet).trialinfo,[thisCondSet{:}])}]; % expand to get indices belonging to bins after restricting
+            removeindex = setdiff(origindex,keepindex);
+            FT_EEG(cSet).trialinfo(removeindex) = -99;
+        end
     end
     % compute ERPs (baseline corrected, resampled, channels already selected)
     FT_ERP{cSet} = compute_erp_on_FT_EEG(FT_EEG(cSet),thisCondSet,'trial','bin');
@@ -438,7 +478,7 @@ end
 % within-class balancing: balance events within classes
 if unbalance_events
     wraptext('Within-class balancing is OFF, such that an unequal distribution of event codes is allowed to contribute to each stimulus class. Make sure you know what you are doing, this can have undesirable effects on how you interpret your results.',80);
-else
+else % HERE WE RECOVER THE ORIGINAL SETINDEX!
     [setindex{1}, setindex{2}] = unpack_binned(setindex{1}, setindex{2}, oldindex{1}, oldindex{2}); % unpack setindex{1} and setindex{2} to get back the original index
     wraptext('Within-class balancing is ON, such that event codes are evenly represented within each stimulus class. If event codes are very unevenly represented in your data, this can result in the loss of many trials. It does however, enforce a balanced design, which is important for interpretation. If this is undesirable behavior, specify ''unbalance_events'' in your methods.',80);
 end
@@ -680,6 +720,7 @@ for cFreq = 1:numel(frequencies)
     settings.measuremethod = measuremethod;
     settings.compute_performance = compute_performance;
     settings.save_confidence = save_confidence;
+    settings.restrict_trainset = restrict_trainset;
     settings.trialinfo = settrialinfo;
     settings.trialindex = settrialindex;
     settings.condset = condSet;

--- a/general_stats/sdt_dprime.m
+++ b/general_stats/sdt_dprime.m
@@ -1,7 +1,20 @@
-% DPRIME  - Signal-detection theory sensitivity measure.
-%
-%  d = dprime(pHit,pFA)
-%  [d,beta] = dprime(pHit,pFA)
+function [d,beta] = sdt_dprime(pHit,pFA, cormethod, nSignal, nNoise)
+%  [d,beta] = sdt_dprime(pHit,pFA,cormethod,nSignal,nNoise)
+
+%  pHit         hit rate: nHits/nSignal
+%  pFA          false alarm rate: nFalseAlarms/nNoise
+%  cormethod    method to correct for 0 and/or 1 values
+%               'arbitrary' (default) simply replacing 0 with .00001 and 1 with .99999
+%               'hautus' loglinear approach corrects for extreme values (0 or 1) by adding 0.5
+%               to both the number of hits and the number of false alarms of all cells, and add 1 to
+%               both the number of signal trials and the number of noise trials of each cell.
+%               'macmillan' Adjust only the extreme values by replacing rates of 0 with 0.5/n and
+%               rates of 1 with (n-0.5)/n, where n is the number of signal or noise trials.
+%               Both 'hautus' and 'macmillan' require nSignal and nNoise to be passed to the
+%               function. 
+%               'none' No correction for 0 and/or 1 values (resulting in Inf values)
+%  nSignal      number of signal trials
+%  nNoise       number of noise trials
 %
 %  PHIT and PFA are numerical arrays of the same shape.
 %  PHIT is the proportion of "Hits":        P(Yes|Signal)
@@ -16,22 +29,47 @@
 %    Psychophysics (2nd Ed.). Huntington, NY: Robert Krieger Publ.Co.
 %  * Macmillan, Neil A. & Creelman, C. Douglas (2005). Detection Theory:
 %    A User's Guide (2nd Ed.). Lawrence Erlbaum Associates.
+%  * Hautus, M. J. (1995). Corrections for extreme proportions and their biasing effects on
+%    estimated values ofd′. Behavior Research Methods, Instruments, & Computers, 27(1), 46–51.
+%  * Macmillan, N. A., & Kaplan, H. L. (1985). Detection theory analysis of group data: estimating
+%    sensitivity from average hit and false-alarm rates. Psychological Bulletin, 98(1), 185–199.
 %  
 %  See also NORMINV, NORMPDF.
 
-function [d,beta] = sdt_dprime(pHit,pFA)
-
-if pHit == 1
-    pHit = .99999;
+if nargin < 3
+    cormethod = 'arbitrary';
 end
-if pHit == 0
-    pHit = .00001;
+if nargin < 4
+    nSignal = [];
 end
-if pFA == 0
-    pFA = .00001;
+if nargin < 5
+    nNoise = [];
 end
-if pFA == 1
-    pFA = .99999;
+if nargin > 2
+    if isempty(nSignal) || isempty(nNoise)
+        error('need to pass nSignal and nNoise to function to apply Hautus or MacMillan correction');
+    end
+    nHits   = pHit .* nSignal;
+    nFA     = pFA .* nNoise;
+end
+if strcmpi(cormethod,'arbitrary')
+    pHit(pHit==1)   = .99999;
+    pFA(pFA==1)     = .99999;
+    pHit(pHit==0)   = .00001;
+    pFA(pFA==0)     = .00001;
+elseif strcmpi(cormethod,'hautus')
+    nHits   = nHits + 0.5;
+    nFA     = nFA + 0.5;
+    nSignal = nSignal + 1;
+    nNoise  = nNoise + 1;
+    pHit    = nHits./nSignal;
+    pFA     = nFA./nNoise;
+elseif strcmpi(cormethod,'macmillan')
+    % replace 0 with 0.5/n and rates of 1 with (n-0.5)/n
+    pHit(pHit==1)   = (nSignal(pHit==1)-0.5)./nSignal(pHit==1);
+    pFA(pFA==1)     = (nNoise(pFA==1)-0.5)./nNoise(pFA==1);
+    pHit(pHit==0)   = 0.5./nSignal(pHit==0);
+    pFA(pFA==0)     = 0.5./nNoise(pFA==0);
 end
 
 %-- Convert to Z scores, no error checking
@@ -48,5 +86,3 @@ if (nargout > 1)
   beta = yHit ./ yFA ;
 end
 
-%%  Return DPRIME and possibly BETA
-%%%%%% End of file DPRIME.M


### PR DESCRIPTION
Two updates:
- It is now possible to plot the outcome of the classifier without labels in the test set, i.e. by plotting the probability each time point is classified as the first class in the class definition. Use cfg.compute_performance = 'no';
- It is is now possible to restrict the number of trials in the train set (e.g. when comparing to another analysis with fewer trials in the train set). Use cfg.restrict_trainset  = [int];
Also other minor fixes, e.g. when plotting symmetrical temporal generalization.